### PR TITLE
Add localStorage persistence for data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,9 +98,29 @@ const ProjectTrackerApp = () => {
       }
     ];
 
-    setUsers(initialUsers);
-    setProjects(initialProjects);
+    const storedUsers = localStorage.getItem('users');
+    const storedProjects = localStorage.getItem('projects');
+
+    if (storedUsers) {
+      setUsers(JSON.parse(storedUsers));
+    } else {
+      setUsers(initialUsers);
+    }
+
+    if (storedProjects) {
+      setProjects(JSON.parse(storedProjects));
+    } else {
+      setProjects(initialProjects);
+    }
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('users', JSON.stringify(users));
+  }, [users]);
+
+  useEffect(() => {
+    localStorage.setItem('projects', JSON.stringify(projects));
+  }, [projects]);
 
   const permissions = {
     administrador: {


### PR DESCRIPTION
## Summary
- load users and projects from localStorage when the app mounts
- save users and projects to localStorage whenever they change

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880ebbd26a08324b7f461f27f95f795