### PR TITLE
Add env example and usage docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
+# Example environment variables for the React app
+
+# URL of your Supabase project (https://xyzcompany.supabase.co)
 REACT_APP_SUPABASE_URL=
+
+# Public anon key for your Supabase project
 REACT_APP_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Sistema integral de gestión y seguimiento de proyectos con control de usuarios 
 
 ## Instalación y Uso
 
+Antes de ejecutar el proyecto copia el archivo `.env.example` a `.env` y completa los valores de `REACT_APP_SUPABASE_URL` y `REACT_APP_SUPABASE_ANON_KEY`.
 ```bash
 # Instalar dependencias
 npm install


### PR DESCRIPTION
## Summary
- document Supabase environment variables in `.env.example`
- explain how to copy `.env.example` in the README

## Testing
- `npm run build` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6881aaf1cf1c83249eccd8c56e4c0ae5