### PR TITLE
Trim login credentials before comparison

### DIFF
--- a/src/components/LoginComponent.jsx
+++ b/src/components/LoginComponent.jsx
@@ -7,10 +7,13 @@ const LoginComponent = ({ users, setCurrentUser, setCurrentView }) => {
 
   const handleLogin = (e) => {
     e.preventDefault();
+    const trimmedUsername = credentials.username.trim();
+    const trimmedPassword = credentials.password.trim();
+
     const user = users.find(
       (u) =>
-        u.username === credentials.username &&
-        u.password === credentials.password &&
+        u.username === trimmedUsername &&
+        u.password === trimmedPassword &&
         u.status === 'activo'
     );
 


### PR DESCRIPTION
## Summary
- Trim username and password before searching users during login

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894e369e3e4832493633847f7de2a45